### PR TITLE
Review of changes that are required for InfluxDB Reactive Java client

### DIFF
--- a/src/main/java/org/influxdb/InfluxDBException.java
+++ b/src/main/java/org/influxdb/InfluxDBException.java
@@ -126,7 +126,7 @@ public class InfluxDBException extends RuntimeException {
     }
   }
 
-  private static InfluxDBException buildExceptionFromErrorMessage(final String errorMessage) {
+  public static InfluxDBException buildExceptionFromErrorMessage(final String errorMessage) {
     if (errorMessage.contains(DATABASE_NOT_FOUND_ERROR)) {
       return new DatabaseNotFoundException(errorMessage);
     }

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -107,14 +107,37 @@ public class InfluxDBImpl implements InfluxDB {
    *          The InfluxDB user name
    * @param password
    *          The InfluxDB user password
-   * @param client
+   * @param okHttpBuilder
    *          The OkHttp Client Builder
    * @param responseFormat
    *          The {@code ResponseFormat} to use for response from InfluxDB
    *          server
    */
-  public InfluxDBImpl(final String url, final String username, final String password, final OkHttpClient.Builder client,
-      final ResponseFormat responseFormat) {
+  public InfluxDBImpl(final String url, final String username, final String password,
+                      final OkHttpClient.Builder okHttpBuilder, final ResponseFormat responseFormat) {
+    this(url, username, password, okHttpBuilder, new Retrofit.Builder(), responseFormat);
+  }
+
+  /**
+   * Constructs a new {@code InfluxDBImpl}.
+   *
+   * @param url
+   *          The InfluxDB server API URL
+   * @param username
+   *          The InfluxDB user name
+   * @param password
+   *          The InfluxDB user password
+   * @param okHttpBuilder
+   *          The OkHttp Client Builder
+   * @param retrofitBuilder
+   *          The Retrofit Builder
+   * @param responseFormat
+   *          The {@code ResponseFormat} to use for response from InfluxDB
+   *          server
+   */
+  public InfluxDBImpl(final String url, final String username, final String password,
+                      final OkHttpClient.Builder okHttpBuilder, final Retrofit.Builder retrofitBuilder,
+                      final ResponseFormat responseFormat) {
     this.messagePack = ResponseFormat.MSGPACK.equals(responseFormat);
     this.hostAddress = parseHostAddress(url);
 
@@ -122,7 +145,7 @@ public class InfluxDBImpl implements InfluxDB {
     setLogLevel(LOG_LEVEL);
 
     this.gzipRequestInterceptor = new GzipRequestInterceptor();
-    OkHttpClient.Builder clonedBuilder = client.build().newBuilder();
+    OkHttpClient.Builder clonedBuilder = okHttpBuilder.build().newBuilder();
     clonedBuilder.addInterceptor(loggingInterceptor).addInterceptor(gzipRequestInterceptor).
       addInterceptor(new BasicAuthInterceptor(username, password));
     Factory converterFactory = null;
@@ -146,7 +169,7 @@ public class InfluxDBImpl implements InfluxDB {
       break;
     }
 
-    this.retrofit = new Retrofit.Builder().baseUrl(url).client(
+    this.retrofit = retrofitBuilder.baseUrl(url).client(
         clonedBuilder.build()).addConverterFactory(converterFactory).build();
     this.influxDBService = this.retrofit.create(InfluxDBService.class);
 

--- a/src/test/java/org/influxdb/impl/RetryCapableBatchWriterTest.java
+++ b/src/test/java/org/influxdb/impl/RetryCapableBatchWriterTest.java
@@ -107,9 +107,11 @@ public class RetryCapableBatchWriterTest {
     InfluxDBException nonRecoverable5 = InfluxDBException.buildExceptionForErrorState(createErrorBody("field type conflict 'abc'"));
     InfluxDBException nonRecoverable6 = new InfluxDBException.RetryBufferOverrunException(createErrorBody("Retry BufferOverrun Exception"));
     InfluxDBException nonRecoverable7 = InfluxDBException.buildExceptionForErrorState(createErrorBody("user is not authorized to write to database"));
-    
+    InfluxDBException nonRecoverable8 = InfluxDBException.buildExceptionForErrorState(createErrorBody("authorization failed"));
+    InfluxDBException nonRecoverable9 = InfluxDBException.buildExceptionForErrorState(createErrorBody("username required"));
+
     List<InfluxDBException> exceptions = Arrays.asList(nonRecoverable1, nonRecoverable2, nonRecoverable3,
-        nonRecoverable4, nonRecoverable5, nonRecoverable6, nonRecoverable7);
+        nonRecoverable4, nonRecoverable5, nonRecoverable6, nonRecoverable7, nonRecoverable8, nonRecoverable9);
     int size = exceptions.size();
     doAnswer(new TestAnswer() {
       int i = 0;
@@ -224,8 +226,15 @@ public class RetryCapableBatchWriterTest {
     Assertions.assertEquals(bp1, captor4Write.getAllValues().get(1));
     //bp2 written
     Assertions.assertEquals(bp2, captor4Write.getAllValues().get(2));
-    
   }
+
+  @Test
+  void defaultExceptionIsRecoverable() {
+    InfluxDBException unknownError = InfluxDBException.buildExceptionForErrorState(createErrorBody("unknown error"));
+
+    Assertions.assertTrue(unknownError.isRetryWorth());
+  }
+
   private static String createErrorBody(String errorMessage) {
     return MessageFormat.format("'{' \"error\": \"{0}\" '}'", errorMessage);
   }


### PR DESCRIPTION
This PR solve [#392](https://github.com/influxdata/influxdb-java/issues/392) by adding possibility to reuse influxdb-java client as a core part of [influxdb-java-reactive](https://github.com/bonitoo-io/influxdb-java-reactive) - **Reactive Java client for InfluxDB**.

#### Summary of changes
1. The `InfluxDBImpl` constructor has parameter for customise `Retrofit.Builder`. That builder is use in **influxdb-java-reactive** client for create reactive version of `InfluxDBService`.
2. The `InfluxDBResultMapper` is able to handle results which a different time precision. This issue is described below
3. The `InfluxDBResultMapper` is able to map `Integer` to `Instant`

#### Precision issue

The `InfluxDBResultMapper` is not able map QueryResults with different precision than Milliseconds.

```java
@Test
void testToPOJO_Precision() {

	String database = "precision_database";
	influxDB.deleteDatabase(database);
	influxDB.createDatabase(database);

	// write in Nanoseconds
	influxDB.write(database, "autogen", InfluxDB.ConsistencyLevel.ONE,
				"h2o_feet,location=coyote_creek level\\ description=\"below 3 feet\",water_level=2.927 1000000000");

	// query in Seconds
	QueryResult queryResults = influxDB.query(new Query("select * from h2o_feet", database), TimeUnit.SECONDS);

	// Mapper expected time in Milliseconds
	List<H2OFeetMeasurement> measurements = new InfluxDBResultMapper().toPOJO(queryResults, H2OFeetMeasurement.class);

	Assertions.assertEquals(1, measurements.size());
	Assertions.assertEquals("coyote_creek", measurements.get(0).location);
	Assertions.assertEquals(2.927D, (double) measurements.get(0).level);
	Assertions.assertEquals("below 3 feet", measurements.get(0).description);
	Assertions.assertEquals(Instant.ofEpochSecond(1), measurements.get(0).time);
}

@Measurement(name = "h2o_feet", timeUnit = TimeUnit.NANOSECONDS)
public static class H2OFeetMeasurement {

	@Column(name = "location", tag = true)
	private String location;

	@Column(name = "water_level")
	private Double level;

	@Column(name = "level description")
	private String description;

	@Column(name = "time")
	private Instant time;
}
```

---
[![codecov](https://codecov.io/gh/bonitoo-io/influxdb-java/branch/reactive-pull-request/graph/badge.svg)](https://codecov.io/gh/bonitoo-io/influxdb-java/branch/reactive-pull-request)

@lxhoan, @ivankudibal , @dubsky, @rhajek can you look at this?