### PR TITLE
Improved streaming query API

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -8,6 +8,7 @@
 - [If there is an error during this background process, is it propagated to the rest of the client ?](#if-there-is-an-error-during-this-background-process-is-it-propagated-to-the-rest-of-the-client-)
 - [How the client responds to concurrent write backpressure from server ?](#how-the-client-responds-to-concurrent-write-backpressure-from-server-)
 - [Is there a way to tell that all query chunks have arrived ?](#is-there-a-way-to-tell-that-all-query-chunks-have-arrived-)
+- [Is there a way to tell the system to stop sending more chunks once I've found what I'm looking for ?](#is-there-a-way-to-tell-the-system-to-stop-sending-more-chunks-once-ive-found-what-im-looking-for-)
 
 ## Security
 
@@ -65,12 +66,28 @@ So in case the number of write requests exceeds Concurrent write setting at serv
 Yes, there is __onComplete__ action that is invoked after successfully end of stream.
 ```java
 influxDB.query(new Query("SELECT * FROM disk", "telegraf"), 10_000,
-        queryResult -> {
-            System.out.println("result = " + queryResult);
-        }, 
-        () -> {
-            System.out.println("The query successfully finished.");
-        });
+    queryResult -> {
+        System.out.println("result = " + queryResult);
+    }, 
+    () -> {
+        System.out.println("The query successfully finished.");
+    });
+```
+
+## Is there a way to tell the system to stop sending more chunks once I've found what I'm looking for ?
+Yes, there is __onNext__ bi-consumer with capability to discontinue a streaming query.
+```java
+influxDB.query(new Query("SELECT * FROM disk", "telegraf"), 10_000, (cancellable, queryResult) -> {
+
+    // found what I'm looking for ?
+    if (foundRequest(queryResult)) {
+        // yes => cancel query
+        cancellable.cancel();
+    }
+
+    // no => process next result
+    processResult(queryResult);
+});
 ```
 
 ## Is default config security setup TLS 1.2 ?

--- a/FAQ.md
+++ b/FAQ.md
@@ -7,7 +7,7 @@
 - [And if so, is there a single thread in the background that is emptying batch to the server ?](#and-if-so-is-there-a-single-thread-in-the-background-that-is-emptying-batch-to-the-server-)
 - [If there is an error during this background process, is it propagated to the rest of the client ?](#if-there-is-an-error-during-this-background-process-is-it-propagated-to-the-rest-of-the-client-)
 - [How the client responds to concurrent write backpressure from server ?](#how-the-client-responds-to-concurrent-write-backpressure-from-server-)
-
+- [Is there a way to tell that all query chunks have arrived ?](#is-there-a-way-to-tell-that-all-query-chunks-have-arrived-)
 
 ## Security
 
@@ -60,6 +60,18 @@ org.influxdb.InfluxDBIOException: java.net.SocketException: Connection reset by 
 Form version 2.9, influxdb-java introduces new error handling feature, the client will try to back off and rewrite failed wites on some recoverable errors (list of recoverable error : [Handling-errors-of-InfluxDB-under-high-load](https://github.com/influxdata/influxdb-java/wiki/Handling-errors-of-InfluxDB-under-high-load))
 
 So in case the number of write requests exceeds Concurrent write setting at server side, influxdb-java can try to make sure no writing points get lost (due to rejection from server)
+
+## Is there a way to tell that all query chunks have arrived ?
+Yes, there is __onComplete__ action that is invoked after successfully end of stream.
+```java
+influxDB.query(new Query("SELECT * FROM disk", "telegraf"), 10_000,
+        queryResult -> {
+            System.out.println("result = " + queryResult);
+        }, 
+        () -> {
+            System.out.println("The query successfully finished.");
+        });
+```
 
 ## Is default config security setup TLS 1.2 ?
 

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -5,6 +5,7 @@ import org.influxdb.dto.Point;
 import org.influxdb.dto.Pong;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
+import retrofit2.Call;
 
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
@@ -103,6 +104,28 @@ public interface InfluxDB {
     /** application/x-msgpack format. */
     MSGPACK
   }
+
+  /**
+   * A cancelable allows to discontinue a streaming query.
+   */
+  public interface Cancellable {
+
+    /**
+     * Cancel the streaming query call.
+     *
+     * @see Call#cancel()
+     */
+    void cancel();
+
+    /**
+     * Return {@code true} if the {@link Cancellable#cancel()} was called.
+     *
+     * @return {@code true} if the {@link Cancellable#cancel()} was called
+     * @see Call#isCanceled()
+     */
+    boolean isCanceled();
+  }
+
   /**
    * Set the loglevel which is used for REST related actions.
    *
@@ -464,11 +487,37 @@ public interface InfluxDB {
    * @param chunkSize
    *            the number of QueryResults to process in one chunk.
    * @param onNext
+   *            the consumer to invoke for each received QueryResult; with capability to discontinue a streaming query
+   */
+  public void query(Query query, int chunkSize, BiConsumer<Cancellable, QueryResult> onNext);
+
+  /**
+   * Execute a streaming query against a database.
+   *
+   * @param query
+   *            the query to execute.
+   * @param chunkSize
+   *            the number of QueryResults to process in one chunk.
+   * @param onNext
    *            the consumer to invoke for each received QueryResult
    * @param onComplete
    *            the onComplete to invoke for successfully end of stream
    */
   public void query(Query query, int chunkSize, Consumer<QueryResult> onNext, Runnable onComplete);
+
+  /**
+   * Execute a streaming query against a database.
+   *
+   * @param query
+   *            the query to execute.
+   * @param chunkSize
+   *            the number of QueryResults to process in one chunk.
+   * @param onNext
+   *            the consumer to invoke for each received QueryResult; with capability to discontinue a streaming query
+   * @param onComplete
+   *            the onComplete to invoke for successfully end of stream
+   */
+  public void query(Query query, int chunkSize, BiConsumer<Cancellable, QueryResult> onNext, Runnable onComplete);
 
   /**
    * Execute a query against a database.

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -451,10 +451,24 @@ public interface InfluxDB {
    *            the query to execute.
    * @param chunkSize
    *            the number of QueryResults to process in one chunk.
-   * @param consumer
+   * @param onNext
    *            the consumer to invoke for each received QueryResult
    */
-  public void query(Query query, int chunkSize, Consumer<QueryResult> consumer);
+  public void query(Query query, int chunkSize, Consumer<QueryResult> onNext);
+
+  /**
+   * Execute a streaming query against a database.
+   *
+   * @param query
+   *            the query to execute.
+   * @param chunkSize
+   *            the number of QueryResults to process in one chunk.
+   * @param onNext
+   *            the consumer to invoke for each received QueryResult
+   * @param onComplete
+   *            the onComplete to invoke for successfully end of stream
+   */
+  public void query(Query query, int chunkSize, Consumer<QueryResult> onNext, Runnable onComplete);
 
   /**
    * Execute a query against a database.

--- a/src/test/java/org/influxdb/MessagePackInfluxDBTest.java
+++ b/src/test/java/org/influxdb/MessagePackInfluxDBTest.java
@@ -7,7 +7,10 @@ import static org.mockito.Mockito.spy;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import org.influxdb.InfluxDB.ResponseFormat;
 import org.influxdb.dto.BatchPoints;
@@ -186,6 +189,51 @@ public class MessagePackInfluxDBTest extends InfluxDBTest {
     Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(1).get(0), timeP2);
     Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(2).get(0), timeP3);
     this.influxDB.deleteDatabase(dbName);
+  }
+
+  @Override
+  @Test
+  public void testChunking() throws InterruptedException {
+    if (this.influxDB.version().startsWith("0.") || this.influxDB.version().startsWith("1.0")) {
+      // do not test version 0.13 and 1.0
+      return;
+    }
+    String dbName = "write_unittest_" + System.currentTimeMillis();
+    this.influxDB.createDatabase(dbName);
+    String rp = TestUtils.defaultRetentionPolicy(this.influxDB.version());
+    BatchPoints batchPoints = BatchPoints.database(dbName).retentionPolicy(rp).build();
+    Point point1 = Point.measurement("disk").tag("atag", "a").addField("used", 60L).addField("free", 1L).build();
+    Point point2 = Point.measurement("disk").tag("atag", "b").addField("used", 70L).addField("free", 2L).build();
+    Point point3 = Point.measurement("disk").tag("atag", "c").addField("used", 80L).addField("free", 3L).build();
+    batchPoints.point(point1);
+    batchPoints.point(point2);
+    batchPoints.point(point3);
+    this.influxDB.write(batchPoints);
+
+    Thread.sleep(2000);
+    final BlockingQueue<QueryResult> queue = new LinkedBlockingQueue<>();
+    Query query = new Query("SELECT * FROM disk", dbName);
+    this.influxDB.query(query, 2, new Consumer<QueryResult>() {
+      @Override
+      public void accept(QueryResult result) {
+        queue.add(result);
+      }});
+
+    Thread.sleep(2000);
+    this.influxDB.deleteDatabase(dbName);
+
+    QueryResult result = queue.poll(20, TimeUnit.SECONDS);
+    Assertions.assertNotNull(result);
+    System.out.println(result);
+    Assertions.assertEquals(2, result.getResults().get(0).getSeries().get(0).getValues().size());
+
+    result = queue.poll(20, TimeUnit.SECONDS);
+    Assertions.assertNotNull(result);
+    System.out.println(result);
+    Assertions.assertEquals(1, result.getResults().get(0).getSeries().get(0).getValues().size());
+
+    result = queue.poll(5, TimeUnit.SECONDS);
+    Assertions.assertNull(result);
   }
 
   @Test


### PR DESCRIPTION
- Added onNext consumer that has capability to discontinue a streaming query
- Added onComplete notification for successfully finished a streaming query

wiki: [How to try it?](
https://github.com/bonitoo-io/influxdb-java/wiki#improved-streaming-query-api)

### New API
```java
public class ChunkingExample {

    // Main thread
    public List<Integer> executeQuery() throws InterruptedException {

        InfluxDB client = null;

        // Creates a countDownLatch in order to wait for the asynch process
        CountDownLatch countDownLatch = new CountDownLatch(1);

        // List to be filled
        List<Integer> entries = new ArrayList<>();

        CustomConsumer consumer = new CustomConsumer(entries, 20, countDownLatch);

        QueryBuilder queryBuilder = QueryBuilder.newQuery("Select * from things").forDatabase("myDatabase");
        Query query = queryBuilder.create();

        //
        // New method:
        // 
        // query(Query query, int chunkSize, BiConsumer<Cancellable, QueryResult> onNext, Runnable onComplete)
        //
        // onNext - the consumer to invoke for each received QueryResult; with capability to discontinue a streaming query
        // onComplete - the onComplete to invoke for successfully end of stream
        //
        // Syntax with the onComplete lambda:
        //
        // client.query(query, 10, consumer, countDownLatch::countDown);
        //
        client.query(query, 10000, consumer, consumer);

        // Wait for the async thread
        countDownLatch.await();

        // return entries to the UI.
        return entries;

    }

    // Asynch Consumer
    public class CustomConsumer implements BiConsumer<InfluxDB.Cancellable, QueryResult>, Runnable {

        private final List<Integer> entries;

        private final int maxItems;

        private final CountDownLatch countDownLatch;

        public CustomConsumer(List<Integer> entries, int maxItems, CountDownLatch countDownLatch) {
            this.entries = entries;
            this.maxItems = maxItems;
            this.countDownLatch = countDownLatch;
        }

        @Override
        public void accept(InfluxDB.Cancellable cancellable, QueryResult response) {

            // process the resultset
            List<QueryResult.Result> results = response.getResults();
            if (results != null && !results.isEmpty() && results.get(0).getSeries() != null) {

                QueryResult.Series series = results.get(0).getSeries().get(0);

                for (List<Object> values : series.getValues()) {

                    // Assuming every value are integer
                    Integer value = (Integer) values.get(1);

                    // Silly filter. In real world the filter is more complex.
                    if (value < 100) {
                        continue;
                    }

                    entries.add(value);

                    // we got the max items
                    if (entries.size() == maxItems) {
                        
                        // say to influx "Stop sending information" and calling the consumer
                        cancellable.cancel();
                        countDownLatch.countDown();
                        return;
                    }
                }
            }
        }

        // In this scenario the client says, there are no more entries from influx.
        @Override
        public void run() {
            countDownLatch.countDown();
        }
    }
}
```

### Old API
```java
public class ChunkingExample {

    // Main thread
    public List<Integer> executeQuery() throws InterruptedException {

        InfluxDB client = null;

        // Creates a countDownLatch in order to wait for the asynch process
        CountDownLatch countDownLatch = new CountDownLatch(1);

        // List to be filled
        List<Integer> entries = new ArrayList<>();

        CustomConsumer consumer = new CustomConsumer(entries, 20, countDownLatch);

        QueryBuilder queryBuilder = QueryBuilder.newQuery("Select * from things").forDatabase("myDatabase");
        Query query = queryBuilder.create();

        client.query(query, 10000, consumer);

        // Wait for the async thread
        countDownLatch.await();

        // return entries to the UI.
        return entries;

    }

    // Asynch Consumer
    public class CustomConsumer implements Consumer<QueryResult> {

        private final List<Integer> entries;

        private final int maxItems;

        private final CountDownLatch countDownLatch;

        public CustomConsumer(List<Integer> entries, int maxItems, CountDownLatch countDownLatch) {
            this.entries = entries;
            this.maxItems = maxItems;
            this.countDownLatch = countDownLatch;
        }

        @Override
        public void accept(QueryResult response) {

            // In this scenario, the entries were return in the last iteration to the UI
            // but the async process (influxdb client) still calling the consumer. We dont do anything.
            // Instead to do this "skipping part", we want to say to influx "Stop sending information" and
            // calling the consumer
            if (countDownLatch.getCount() == 0) {
                return;
            }

            // In this scenario the client says, there are no more entries from influx.
            if (response.getError().equals("DONE")) {
                countDownLatch.countDown();
                return;
            }

            // process the resultset
            if (!response.getResults().isEmpty() && response.getResults().get(0).getSeries() != null) {

                Series series = response.getResults().get(0).getSeries().get(0);

                for (List<Object> values : series.getValues()) {

                    // Assuming every value are integer
                    Integer value = (Integer) values.get(1);

                    // Silly filter. In real world the filter is more complex.
                    if (value < 100) {
                        continue;
                    }

                    entries.add(value);

                    // we got the max items
                    if (entries.size() == maxItems) {
                        countDownLatch.countDown();
                        return;
                    }
                }
            }
        }
    }
}
```
